### PR TITLE
Truffle config import fix +`contracts/` README.md updates

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,30 +1,24 @@
 # No Loss Dao Contracts
 
-In networks section of deployed builds (in NoLossDao_v0.json and PoolDeposits.json) are the contracts addresses. For upgradeable DAO, can also find address in kovan.json
+In networks section of the deployed builds (in NoLossDao_v0.json and PoolDeposits.json) are the contracts' addresses. For upgradeable DAO, can also find address in `kovan.json` (in `.openzeppelin` folder)
 
-### install
+## Install
 
 ```bash
 yarn
 ```
 
-### Run the tests:
+## Run the tests
 
 ```bash
 yarn run test
-```
-
-```bash
 yarn run coverage
 ```
 
-### Clean Deploy
+## Clean Deploy
 
 ```bash
 yarn run clean
-```
-
-```bash
 yarn run deploy -- --network <network name you want to deploy to>
 ```
 
@@ -36,13 +30,13 @@ yarn run save-deployment
 
 ### Upgrade
 
-Prepair the upgrade by running instead of `yarn run clean`:
+Prepare the upgrade by running the below, instead of `yarn run clean`:
 
 ```bash
 yarn run prepair-upgrade
 ```
 
-#### Important After an upgrade or a deploy carefully examine the contents of both `deployed-builds/contracts` and `.openzeppelin` to make sure everything is in order before comiting or moving on.
+**IMPORTANT! After an upgrade or a deploy, carefully examine the contents of both `deployed-builds/contracts` and `.openzeppelin` to ensure everything is in order before comiting or moving on**
 
 ### License
 

--- a/contracts/truffle-config.js
+++ b/contracts/truffle-config.js
@@ -5,7 +5,7 @@ const {
   rinkebyProviderUrl,
   goerliProviderUrl,
   kovanProviderUrl,
-} = require('./secretsManagerCi.js');
+} = require('./secretsManager.js');
 
 const blockchainNodeHost = process.env.BLOCKCHAIN_NODE_HOST || 'localhost';
 

--- a/contracts/truffle-config.js
+++ b/contracts/truffle-config.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const HDWalletProvider = require('truffle-hdwallet-provider');
 const {
   mnemonic,
@@ -6,7 +5,7 @@ const {
   rinkebyProviderUrl,
   goerliProviderUrl,
   kovanProviderUrl,
-} = require('./secretsManager.js');
+} = require('./secretsManagerCi.js');
 
 const blockchainNodeHost = process.env.BLOCKCHAIN_NODE_HOST || 'localhost';
 


### PR DESCRIPTION
I could not run `yarn run migrate` in contracts, and the culprit was a different name in `truffle-config`. Also fixed the README.md as per my linter + made some grammar amends.